### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/ndmunozca/b9399f11-6710-4ae9-86c8-98c0be4d7643/ea1128e4-e060-4822-87c1-10c340ebfa4c/_apis/work/boardbadge/3c90fd1b-0fd6-4e21-8ce7-73f7ce150010)](https://dev.azure.com/ndmunozca/b9399f11-6710-4ae9-86c8-98c0be4d7643/_boards/board/t/ea1128e4-e060-4822-87c1-10c340ebfa4c/Microsoft.RequirementCategory)
 # ejemplo-1


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/ndmunozca/b9399f11-6710-4ae9-86c8-98c0be4d7643/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.